### PR TITLE
osprepare: Remove redundant reslice of packages slice

### DIFF
--- a/osprepare/distro.go
+++ b/osprepare/distro.go
@@ -212,7 +212,7 @@ func (d *clearLinuxDistro) getID() string {
 // Correctly split and format the command, using sudo if appropriate, as a
 // common mechanism for the various package install functions.
 func sudoFormatCommand(command string, packages []string) bool {
-	toInstall := strings.Join(packages[0:], " ")
+	toInstall := strings.Join(packages, " ")
 
 	var executable string
 	var args string


### PR DESCRIPTION
In a previous out of tree configuration this was required, however this
workaround seems to have been toolchain specific so is now removed for
hygiene.

Signed-off-by: Ikey Doherty michael.i.doherty@intel.com
